### PR TITLE
Clear Parcel cache before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "build": "parcel build",
         "fix": "yarn eslint . --ignore-path .gitignore --ext .js,.jsx,.ts,.tsx --fix",
         "lint": "tsc && eslint . --ignore-path .gitignore --ext .js,.jsx,.ts,.tsx && git diff --check",
-        "prepack": "rm -rf dist && yarn build && yarn typedoc",
+        "prepack": "rm -rf .parcel-cache dist && yarn build && yarn typedoc",
         "test": "echo 'TODO: No tests specified yet.'",
         "watch": "parcel watch"
     },


### PR DESCRIPTION
The Parcel cache tends to cause weird and hard-to-debug bugs. We definitely need to clear that before creating a package for release.